### PR TITLE
Add monster rank availability JSON (Ferias carve reference)

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "data:extract:bin": "uv run --project .. python ../scripts/extract_item_data.py && uv run --project .. python ../scripts/extract_partbreak_data.py && uv run --project .. python ../scripts/extract_hcc_carves.py && uv run --project .. python ../scripts/extract_carve_data.py",
-    "data:build": "npm run data:extract:bin && node scripts/build-data.mjs",
+    "data:build": "npm run data:extract:bin && node scripts/build-data.mjs && node scripts/build-monster-ranks.mjs",
     "dev": "npm run data:build && astro dev",
     "build": "npm run data:build && astro build",
     "preview": "astro preview",

--- a/site/scripts/build-monster-ranks.mjs
+++ b/site/scripts/build-monster-ranks.mjs
@@ -1,0 +1,277 @@
+import { access, constants } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const siteRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(siteRoot, '..');
+const generatedDir = path.join(siteRoot, 'src', 'data', 'generated');
+const monsterNamesPath = path.join(repoRoot, 'g1_data', 'monster_names.json');
+const feriasMonsIndexPath = path.join(repoRoot, 'ferias_reference', 'mons', 'mons_h.htm');
+const outPath = path.join(generatedDir, 'monster-ranks.json');
+
+const RANK_KEYS = ['lr', 'hr', 'arena', 'hr100', 'gr'];
+
+/**
+ * G1 name -> Ferias carve page basename (without _h.htm), or null if no Ferias page.
+ */
+const NAME_TO_FERIAS_BASE = {
+  Bulluk: 'brook',
+  'Aqra Vashim': 'aqura',
+  Belkuros: 'beru',
+  Abiorg: 'abio',
+  Draguros: 'doragyu',
+  Grenzebul: 'guren',
+  /** Black Fatalis: index lists "Fatalis" as plain text, not a link */
+  Fatalis: 'mira',
+  'Crimson Fatalis': 'miraval',
+  'Old Fatalis': 'miraru',
+  MaybeFelyne: 'airu',
+  'Yama Tsukami2': 'yama',
+  /** Ferias labels this "Unknown (ラ・ロ)" */
+  Unknown: 'ra-ro',
+  Pugis: null,
+  'Veggie Elder': null,
+  'Canyon Objects': null,
+  'Canyon Rocks': null,
+  Alpelo: null,
+  Vorsphyroa: null,
+  Levidiora: null,
+  Falnocatrice: null,
+  Argasioth: null,
+  Aurisioth: null
+};
+
+function normalizeName(s) {
+  return s
+    .toLowerCase()
+    .replace(/［.*?］/g, '')
+    .replace(/\[.*?\]/g, '')
+    .replace(/（.*?）/g, '')
+    .replace(/[・\-']/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * @param {string} html
+ * @returns {Map<string, string>}
+ */
+function parseFeriasIndex(html) {
+  const map = new Map();
+  const re = /href="([a-zA-Z0-9_-]+)_h\.htm"[^>]*>([^<]+)/g;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const base = m[1];
+    const label = m[2].replace(/^├|^└|^　/, '').trim();
+    const key = normalizeName(label);
+    if (key && !map.has(key)) {
+      map.set(key, base);
+    }
+  }
+  return map;
+}
+
+function stripBracketSuffix(monsname) {
+  return monsname.replace(/\[[^\]]*\]/g, '').replace(/（[^）]*）/g, '').trim();
+}
+
+function thInnerText(raw) {
+  return raw.replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').trim();
+}
+
+/**
+ * Ferias carve pages use a header row with LR / HR / Arena / Elite / GR (and variants).
+ * Some pages use broken HTML (duplicate <tr>); scan early <table> rows for rank-like <th> cells.
+ *
+ * @param {string} html
+ * @returns {string[]}
+ */
+function parseCarveRankHeaders(html) {
+  const body = html.split(/<\/body>/i)[0] ?? html;
+  const tableMatch = body.match(/<table[^>]*>/i);
+  if (!tableMatch || tableMatch.index === undefined) {
+    return [];
+  }
+  const slice = body.slice(tableMatch.index, tableMatch.index + 12000);
+  const rankHeader = /^(LR|HR\d*|HR|Arena|Elite|GR|Dual Threat|Zenith)/i;
+  const trRe = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+  let best = [];
+  let tr;
+  while ((tr = trRe.exec(slice)) !== null) {
+    const row = tr[1];
+    const thRaw = [...row.matchAll(/<th[^>]*>([\s\S]*?)<\/th>/gi)].map((x) => thInnerText(x[1]));
+    const texts = thRaw.filter(Boolean);
+    const rankCells = texts.filter((t) => rankHeader.test(t));
+    if (rankCells.length > best.length) {
+      best = texts;
+    }
+    if (rankCells.length >= 2) {
+      break;
+    }
+  }
+  return best;
+}
+
+/**
+ * @param {string[]} headers
+ */
+function headersToRanks(headers) {
+  const set = new Set();
+  const hasLrCol = headers.some((h) => h.trim() === 'LR');
+  for (const h of headers) {
+    const u = h.trim();
+    if (u === 'LR') {
+      set.add('lr');
+    }
+    if (/^HR\d/.test(u) || u === 'HR') {
+      set.add('hr');
+      if (hasLrCol) {
+        set.add('lr');
+      }
+    }
+    if (u === 'Arena') {
+      set.add('arena');
+    }
+    if (u === 'Elite') {
+      set.add('hr100');
+    }
+    if (u === 'GR') {
+      set.add('gr');
+    }
+  }
+  return set;
+}
+
+/**
+ * @param {Set<string>} fromFerias
+ */
+function ranksForG1(fromFerias) {
+  const out = {};
+  for (const k of RANK_KEYS) {
+    out[k] = fromFerias.has(k);
+  }
+  out.gr = false;
+  return out;
+}
+
+function extractMonsname(html) {
+  const m = html.match(/id\s*=\s*["']?monsname["']?\s*>([^<]+)/i);
+  return m ? m[1].trim() : '';
+}
+
+async function main() {
+  try {
+    await access(feriasMonsIndexPath, constants.R_OK);
+  } catch {
+    console.warn(
+      'Skipping monster-ranks generation: ferias_reference/mons/mons_h.htm not found (clone MHFZ-Ferias-English-Project into ferias_reference/ to regenerate).'
+    );
+    return;
+  }
+
+  const [namesRaw, indexHtml] = await Promise.all([
+    readFile(monsterNamesPath, 'utf8'),
+    readFile(feriasMonsIndexPath, 'utf8')
+  ]);
+
+  /** @type {Record<string, string>} */
+  const monsterNames = JSON.parse(namesRaw);
+  const feriasByNormName = parseFeriasIndex(indexHtml);
+
+  /** @type {Record<string, unknown>} */
+  const byId = {};
+
+  const ids = Object.keys(monsterNames).sort((a, b) => Number(a) - Number(b));
+
+  for (const id of ids) {
+    const name = monsterNames[id];
+    let base = NAME_TO_FERIAS_BASE[name];
+    if (base === undefined) {
+      base = feriasByNormName.get(normalizeName(name)) ?? null;
+    }
+
+    /** @type {Record<string, boolean>} */
+    let ranks;
+    /** @type {string[]} */
+    const uncertainty = [];
+
+    if (base === null) {
+      ranks = { lr: true, hr: true, arena: true, hr100: true, gr: false };
+      uncertainty.push(
+        'No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope).'
+      );
+    } else {
+      const carvePath = path.join(repoRoot, 'ferias_reference', 'mons', `${base}_h.htm`);
+      let html;
+      try {
+        html = await readFile(carvePath, 'utf8');
+      } catch {
+        ranks = { lr: true, hr: true, arena: true, hr100: true, gr: false };
+        uncertainty.push(`Ferias file ${base}_h.htm missing; using fallback ranks.`);
+        byId[id] = {
+          name,
+          feriasCarvePage: `${base}_h.htm`,
+          ranks,
+          uncertainty
+        };
+        continue;
+      }
+
+      const monsnameRaw = extractMonsname(html);
+      const monsname = stripBracketSuffix(monsnameRaw);
+
+      if (
+        monsname &&
+        normalizeName(monsname) !== normalizeName(name) &&
+        !(name === 'Rocks' && monsname === 'Rock')
+      ) {
+        uncertainty.push(
+          `Ferias monsname "${monsnameRaw}" may not match G1 "${name}"; ranks taken from ${base}_h.htm carve columns.`
+        );
+      }
+
+      const headers = parseCarveRankHeaders(html);
+      const fromFerias = headersToRanks(headers);
+
+      if (fromFerias.size === 0) {
+        ranks = { lr: true, hr: true, arena: true, hr100: true, gr: false };
+        uncertainty.push(
+          'No carve rank columns parsed (empty or nonstandard table); assumed all G1 ranks except gr.'
+        );
+      } else {
+        ranks = ranksForG1(fromFerias);
+      }
+    }
+
+    const entry = {
+      name,
+      ranks
+    };
+    if (base !== null) {
+      entry.feriasCarvePage = `${base}_h.htm`;
+    }
+    if (uncertainty.length) {
+      entry.uncertainty = uncertainty;
+    }
+    byId[id] = entry;
+  }
+
+  const payload = {
+    schema:
+      'Per-monster rank flags from MHFZ Ferias English carve tables (mons/*_h.htm). lr/hr from LR and HR columns; arena from Arena when present; hr100 from Elite (HR100); gr is always false for this G1 wiki. Ferias is a newer game — treat as reference only.',
+    ranks: RANK_KEYS,
+    monsters: byId
+  };
+
+  await mkdir(generatedDir, { recursive: true });
+  await writeFile(outPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  console.log(`Wrote ${outPath} (${ids.length} monsters)`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/site/src/data/generated/monster-ranks.json
+++ b/site/src/data/generated/monster-ranks.json
@@ -1,0 +1,1404 @@
+{
+  "schema": "Per-monster rank flags from MHFZ Ferias English carve tables (mons/*_h.htm). lr/hr from LR and HR columns; arena from Arena when present; hr100 from Elite (HR100); gr is always false for this G1 wiki. Ferias is a newer game — treat as reference only.",
+  "ranks": [
+    "lr",
+    "hr",
+    "arena",
+    "hr100",
+    "gr"
+  ],
+  "monsters": {
+    "1": {
+      "name": "Rathian",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "reia_h.htm"
+    },
+    "2": {
+      "name": "Fatalis",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "mira_h.htm"
+    },
+    "3": {
+      "name": "Kelbi",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "kerubi_h.htm"
+    },
+    "4": {
+      "name": "Mosswine",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "mos_h.htm"
+    },
+    "5": {
+      "name": "Bullfango",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "buru_h.htm"
+    },
+    "6": {
+      "name": "Yian Kut-Ku",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "kukku_h.htm"
+    },
+    "7": {
+      "name": "Lao-Shan Lung",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "rao_h.htm"
+    },
+    "8": {
+      "name": "Cephadrome",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "dosgare_h.htm"
+    },
+    "9": {
+      "name": "Felyne",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "airu_h.htm"
+    },
+    "10": {
+      "name": "Veggie Elder",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "11": {
+      "name": "Rathalos",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "reusu_h.htm"
+    },
+    "12": {
+      "name": "Aptonoth",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "apono_h.htm"
+    },
+    "13": {
+      "name": "Genprey",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "gene_h.htm"
+    },
+    "14": {
+      "name": "Diablos",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "dea_h.htm"
+    },
+    "15": {
+      "name": "Khezu",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "furu_h.htm"
+    },
+    "16": {
+      "name": "Velociprey",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "ran_h.htm"
+    },
+    "17": {
+      "name": "Gravios",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "gura_h.htm"
+    },
+    "18": {
+      "name": "MaybeFelyne",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "airu_h.htm",
+      "uncertainty": [
+        "Ferias monsname \"Felyne\" may not match G1 \"MaybeFelyne\"; ranks taken from airu_h.htm carve columns."
+      ]
+    },
+    "19": {
+      "name": "Vespoid",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "rango_h.htm"
+    },
+    "20": {
+      "name": "Gypceros",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "geryo_h.htm"
+    },
+    "21": {
+      "name": "Plesioth",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "gano_h.htm"
+    },
+    "22": {
+      "name": "Basarios",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "basa_h.htm"
+    },
+    "23": {
+      "name": "Melynx",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "merura_h.htm"
+    },
+    "24": {
+      "name": "Hornetaur",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "kanta_h.htm"
+    },
+    "25": {
+      "name": "Apceros",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "apuke_h.htm"
+    },
+    "26": {
+      "name": "Monoblos",
+      "ranks": {
+        "lr": true,
+        "hr": false,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "mono_h.htm"
+    },
+    "27": {
+      "name": "Velocidrome",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "dosran_h.htm"
+    },
+    "28": {
+      "name": "Gendrome",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "dosgene_h.htm"
+    },
+    "29": {
+      "name": "Rocks",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "30": {
+      "name": "Ioprey",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "ios_h.htm"
+    },
+    "31": {
+      "name": "Iodrome",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "dosios_h.htm"
+    },
+    "32": {
+      "name": "Pugis",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "33": {
+      "name": "Kirin",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "kirin_h.htm"
+    },
+    "34": {
+      "name": "Cephalos",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "gare_h.htm"
+    },
+    "35": {
+      "name": "Giaprey",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "giano_h.htm"
+    },
+    "36": {
+      "name": "Crimson Fatalis",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "miraval_h.htm"
+    },
+    "37": {
+      "name": "Pink Rathian",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "reiasa_h.htm"
+    },
+    "38": {
+      "name": "Blue Yian Kut-Ku",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "kukkuao_h.htm"
+    },
+    "39": {
+      "name": "Purple Gypceros",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "geryoao_h.htm"
+    },
+    "40": {
+      "name": "Yian Garuga",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "garuru_h.htm"
+    },
+    "41": {
+      "name": "Silver Rathalos",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "reusugin_h.htm"
+    },
+    "42": {
+      "name": "Gold Rathian",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "reiakin_h.htm"
+    },
+    "43": {
+      "name": "Black Diablos",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "deakuro_h.htm"
+    },
+    "44": {
+      "name": "White Monoblos",
+      "ranks": {
+        "lr": true,
+        "hr": false,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "monosiro_h.htm"
+    },
+    "45": {
+      "name": "Red Khezu",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "furuaka_h.htm"
+    },
+    "46": {
+      "name": "Green Plesioth",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "ganomidori_h.htm"
+    },
+    "47": {
+      "name": "Black Gravios",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "gurakuro_h.htm"
+    },
+    "48": {
+      "name": "Daimyo Hermitaur",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "daimyo_h.htm"
+    },
+    "49": {
+      "name": "Azure Rathalos",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "reusuao_h.htm"
+    },
+    "50": {
+      "name": "Ashen Lao-Shan Lung",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "raoao_h.htm"
+    },
+    "51": {
+      "name": "Blangonga",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "dodobura_h.htm"
+    },
+    "52": {
+      "name": "Congalala",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "babakonga_h.htm"
+    },
+    "53": {
+      "name": "Rajang",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "ra_h.htm"
+    },
+    "54": {
+      "name": "Kushala Daora",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "kusha_h.htm"
+    },
+    "55": {
+      "name": "Shen Gaoren",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "shen_h.htm"
+    },
+    "56": {
+      "name": "Great Thunderbug",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "raikou_h.htm"
+    },
+    "57": {
+      "name": "Shakalaka",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "cyacya_h.htm"
+    },
+    "58": {
+      "name": "Yama Tsukami",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "yama_h.htm"
+    },
+    "59": {
+      "name": "Chameleos",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "oo_h.htm"
+    },
+    "60": {
+      "name": "Rusted Kushala Daora",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "61": {
+      "name": "Blango",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "bura_h.htm"
+    },
+    "62": {
+      "name": "Conga",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "konga_h.htm"
+    },
+    "63": {
+      "name": "Remobra",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "gabu_h.htm"
+    },
+    "64": {
+      "name": "Lunastra",
+      "ranks": {
+        "lr": true,
+        "hr": false,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "nana_h.htm"
+    },
+    "65": {
+      "name": "Teostra",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "teo_h.htm"
+    },
+    "66": {
+      "name": "Hermitaur",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "gami_h.htm"
+    },
+    "67": {
+      "name": "Shogun Ceanataur",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "syougun_h.htm"
+    },
+    "68": {
+      "name": "Bulldrome",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "dosburu_h.htm"
+    },
+    "69": {
+      "name": "Anteka",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "gau_h.htm"
+    },
+    "70": {
+      "name": "Popo",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "popo_h.htm"
+    },
+    "71": {
+      "name": "Old Fatalis",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "miraru_h.htm",
+      "uncertainty": [
+        "Ferias monsname \"White Fatalis\" may not match G1 \"Old Fatalis\"; ranks taken from miraru_h.htm carve columns."
+      ]
+    },
+    "72": {
+      "name": "Yama Tsukami2",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "yama_h.htm",
+      "uncertainty": [
+        "Ferias monsname \"Yama Tsukami\" may not match G1 \"Yama Tsukami2\"; ranks taken from yama_h.htm carve columns."
+      ]
+    },
+    "73": {
+      "name": "Ceanataur",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "yao_h.htm"
+    },
+    "74": {
+      "name": "Hypnocatrice",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "75": {
+      "name": "Lavasioth",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "76": {
+      "name": "Tigrex",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "tiga_h.htm"
+    },
+    "77": {
+      "name": "Akantor",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "akamu_h.htm"
+    },
+    "78": {
+      "name": "Vivid Hypnocatrice",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "79": {
+      "name": "Red Lavasioth",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "80": {
+      "name": "Espinas",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "esp_h.htm"
+    },
+    "81": {
+      "name": "Flaming Espinas",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "82": {
+      "name": "Pale Hypnocatrice",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "83": {
+      "name": "Aqra Vashim",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "aqura_h.htm",
+      "uncertainty": [
+        "Ferias monsname \"Akura Vashimu\" may not match G1 \"Aqra Vashim\"; ranks taken from aqura_h.htm carve columns."
+      ]
+    },
+    "84": {
+      "name": "Aqra Jebia",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "85": {
+      "name": "Belkuros",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "beru_h.htm",
+      "uncertainty": [
+        "Ferias monsname \"Berukyurosu\" may not match G1 \"Belkuros\"; ranks taken from beru_h.htm carve columns."
+      ]
+    },
+    "86": {
+      "name": "Cactus",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "saboten_h.htm"
+    },
+    "87": {
+      "name": "Canyon Objects",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "88": {
+      "name": "Canyon Rocks",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "89": {
+      "name": "Pariapuria",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "paria_h.htm"
+    },
+    "90": {
+      "name": "Pearl Espinas",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "91": {
+      "name": "Kamu Orgaron",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "92": {
+      "name": "Nono Orgaron",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "93": {
+      "name": "Laviente",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "94": {
+      "name": "Duragaua",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "95": {
+      "name": "Draguros",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "doragyu_h.htm",
+      "uncertainty": [
+        "Ferias monsname \"Doragyurosu\" may not match G1 \"Draguros\"; ranks taken from doragyu_h.htm carve columns."
+      ]
+    },
+    "96": {
+      "name": "Grenzebul",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "guren_h.htm",
+      "uncertainty": [
+        "Ferias monsname \"Gurenzeburu\" may not match G1 \"Grenzebul\"; ranks taken from guren_h.htm carve columns."
+      ]
+    },
+    "97": {
+      "name": "Bulluk",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "brook_h.htm",
+      "uncertainty": [
+        "Ferias monsname \"Burukku\" may not match G1 \"Bulluk\"; ranks taken from brook_h.htm carve columns."
+      ]
+    },
+    "98": {
+      "name": "Alpelo",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "99": {
+      "name": "Rukodiora",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "ruco_h.htm"
+    },
+    "100": {
+      "name": "Unknown",
+      "ranks": {
+        "lr": false,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "ra-ro_h.htm"
+    },
+    "101": {
+      "name": "Gogomoa",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "gogo_h.htm"
+    },
+    "102": {
+      "name": "Kokomoa",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "koko_h.htm"
+    },
+    "103": {
+      "name": "Taikun Zamuza",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "taikun_h.htm"
+    },
+    "104": {
+      "name": "Abiorg",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": false,
+        "hr100": true,
+        "gr": false
+      },
+      "feriasCarvePage": "abio_h.htm",
+      "uncertainty": [
+        "Ferias monsname \"Abiorugu\" may not match G1 \"Abiorg\"; ranks taken from abio_h.htm carve columns."
+      ]
+    },
+    "105": {
+      "name": "Quarzeps",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "106": {
+      "name": "Odibataurus",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "107": {
+      "name": "Vorsphyroa",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "108": {
+      "name": "Levidiora",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "109": {
+      "name": "Anorpatis",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "110": {
+      "name": "Hyujikiki",
+      "ranks": {
+        "lr": false,
+        "hr": false,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "hyuji_h.htm"
+    },
+    "111": {
+      "name": "Midogaron",
+      "ranks": {
+        "lr": false,
+        "hr": false,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "mido_h.htm"
+    },
+    "112": {
+      "name": "Giaorg",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "113": {
+      "name": "Mi Ru",
+      "ranks": {
+        "lr": false,
+        "hr": false,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "mi-ru_h.htm"
+    },
+    "114": {
+      "name": "Falnocatrice",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "115": {
+      "name": "Pokaradon",
+      "ranks": {
+        "lr": false,
+        "hr": false,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "pokaradon_h.htm"
+    },
+    "116": {
+      "name": "Shantien",
+      "ranks": {
+        "lr": false,
+        "hr": false,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "shan_h.htm"
+    },
+    "117": {
+      "name": "Pokara",
+      "ranks": {
+        "lr": false,
+        "hr": false,
+        "arena": false,
+        "hr100": false,
+        "gr": false
+      },
+      "feriasCarvePage": "pokara_h.htm"
+    },
+    "119": {
+      "name": "Aurisioth",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    },
+    "120": {
+      "name": "Argasioth",
+      "ranks": {
+        "lr": true,
+        "hr": true,
+        "arena": true,
+        "hr100": true,
+        "gr": false
+      },
+      "uncertainty": [
+        "No Ferias carve index entry in mons_h.htm; kept lr/hr/arena/hr100, gr false (G1 scope)."
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `site/src/data/generated/monster-ranks.json`, listing which ranks each monster in `g1_data/monster_names.json` appears to have, using the **MHFZ Ferias English** carve pages (`mons/*_h.htm`) as a reference only.

## Details

- **Ranks**: `lr`, `hr`, `arena`, `hr100` (Elite in Ferias), `gr` — **`gr` is always `false`** for this G1 wiki scope per request.
- **Source**: First carve table header row on each monster's `*_h.htm` page; `HR`/`HR51`-style columns imply **high rank**; **low rank** is only set when an explicit **LR** column exists (so HR-only tables like Fatalis do not incorrectly get `lr: true`).
- **Build**: `site/scripts/build-monster-ranks.mjs` runs after `build-data.mjs` in `npm run data:build`. If `ferias_reference/mons/mons_h.htm` is missing, the script skips (Ferias is gitignored); the committed JSON keeps CI working without a Ferias clone.
- **Manual overrides** in the script for G1 names that differ from Ferias labels (e.g. Bulluk→Burukku, Aqra Vashim→Akura Vashimu, Fatalis family pages, Unknown→ラ・ロ carve page).
- **`uncertainty`** notes on entries where the Ferias `monsname` may not match the G1 label (e.g. Old Fatalis vs White Fatalis) or where there is no Ferias carve index link.

## Note

`ferias_reference/` remains in `.gitignore`; developers who want to regenerate locally should clone [MHFZ-Ferias-English-Project](https://github.com/xl3lackout/MHFZ-Ferias-English-Project) into `ferias_reference/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a612f33-3a6e-4e1e-8a60-60394cb5fd4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a612f33-3a6e-4e1e-8a60-60394cb5fd4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

