### PR TITLE
Refine item acquisition source text formatting

### DIFF
--- a/site/src/pages/items/[slug].astro
+++ b/site/src/pages/items/[slug].astro
@@ -108,6 +108,20 @@ const currencyUnit = item.isGz ? 'Gz' : 'z';
 const getRankLabel = (rank: string) => rankLabels[rank] || rank.toUpperCase();
 const getRankPanelClass = (rank: string) => (rankLabels[rank] ? `rank-panel--${rank}` : '');
 const getRankActivePillClass = (rank: string) => (rankLabels[rank] ? `rank-pill--active-${rank}` : 'rank-pill--active');
+const isPresentDetail = (detail: string) => detail.trim() !== '' && detail.trim() !== '-';
+const getMonsterSourceLabel = (row: MonsterSourceRow) => {
+  const detail = row.detail || '';
+  if (row.methodType === 'carve') {
+    return isPresentDetail(detail) ? detail : row.methodLabel;
+  }
+  if (row.methodType === 'capture') {
+    return row.methodLabel;
+  }
+  if (row.methodType === 'part_break') {
+    return isPresentDetail(detail) ? `${row.methodLabel}: ${detail}` : row.methodLabel;
+  }
+  return isPresentDetail(detail) ? `${row.methodLabel}: ${detail}` : row.methodLabel;
+};
 
 const rankSections: RankSection[] = acquisitionRanks.map((rankSection) => ({
   ...rankSection,
@@ -216,7 +230,7 @@ const rankSections: RankSection[] = acquisitionRanks.map((rankSection) => ({
                                   )}
                                 </td>
                                 <td>
-                                  {[row.methodLabel, row.detail].filter(Boolean).join(': ')}
+                                  {getMonsterSourceLabel(row)}
                                 </td>
                                 <td>{typeof row.chance === 'number' ? `${row.chance}%` : 'Unknown'}</td>
                                 <td>{typeof row.quantity === 'number' ? `x${row.quantity}` : 'x?'}</td>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update item acquisition monster source formatting rules to match expected display:
  - `carve`: show detail only (e.g. `Tail Carve (1)`, `Body Carves`, `Shiny Drops`)
  - `capture`: show method label only (`Capture`)
  - `part_break`: show both label and detail (`Part Break: Head`)
- keep the combined single `Source` column from the previous simplification

## Testing
- `npm run build` (from `site/`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d71c07a5-2ce3-4e76-8639-f7a89c1a78be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d71c07a5-2ce3-4e76-8639-f7a89c1a78be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

